### PR TITLE
Update bindings for ctypes-0.6 compatibility.

### DIFF
--- a/src/zstd_stubs.ml
+++ b/src/zstd_stubs.ml
@@ -1,8 +1,7 @@
 open Ctypes
 
 module Bindings
-  (F : sig type _ fn
-           val foreign : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) fn end) =
+  (F : Cstubs.FOREIGN) =
 struct
   open F
 


### PR DESCRIPTION
The next release of ctypes will include a small backwards-incompatible change to the `Cstubs` interface: `@->` and `returning` used in a bindings functor should now be imported from the functor argument, not from `Ctypes`.

See the following PR for more details: https://github.com/ocamllabs/ocaml-ctypes/pull/389

This pull request changes the `Zstd_stubs` module to be compatible both with existing versions of ctypes and with the forthcoming 0.6 release.
