### PR TITLE
ctypes: fix compatibility with 0.21.0

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
   (public_name zstd.stubs)
   (wrapped false)
   (modules zstd_stubs)
-  (libraries ctypes))
+  (libraries ctypes.stubs))
 
 (executable
   (name zstd_gen)


### PR DESCRIPTION
In ctypes < 0.21.0, the `ctypes` and `ctypes.stubs` libraries were installed in the same directory, so depending on one would make the other one visible. ctypes 0.21.0 installs them in different directories so this makes it an error. `zstd.stubs` actually uses `ctypes.stubs` so it should depend on it.
