### PR TITLE
fix: external_library_name

### DIFF
--- a/stubs/dune
+++ b/stubs/dune
@@ -3,7 +3,7 @@
  (public_name zstd.stubs)
  (libraries ctypes.stubs integers)
  (ctypes
-  (external_library_name libzstd)
+  (external_library_name zstd)
   (headers (include "zstd.h"))
   (type_description
    (instance Types)


### PR DESCRIPTION
it seems like `external_library_name` needs to be `zstd` instead, otherwise dune will generate a link flag `-llibzstd` which doesn't exist. the correct one is `-lzstd`.